### PR TITLE
Add Docker running check to run script

### DIFF
--- a/run-plex
+++ b/run-plex
@@ -19,8 +19,16 @@ echo " This script interactively runs the default, previously configured"
 echo " container-based Plex Media Server based out of this directory"
 
 echo ""
-echo "Make sure you have Docker running"
-prompt-to-proceed
+echo " Checking if Docker is running..."
+if (! docker stats --no-stream ); then
+  echo ""
+  echo "!!! Docker is not running, please start Docker and !!!"
+  echo "!!! once Docker is fully started, re-run this script !!!"
+  echo ""
+  exit 86
+fi
+echo " ...Docker is running"
+echo ""
 
 echo " You will first need a Plex Server Claim Token"
 echo " In a web browser, go to..."


### PR DESCRIPTION
This change adds a check to the run script to ensure docker is running.  This check should work on both macOS and linux.

### Behavior Change
#### Old
```
Make sure you have Docker running

Do you wish to proceed (Press any key to continue or 'n' to exit)? 
```

#### New
##### Happy Path
If Docker is running, then there is now no longer a prompt to proceed and script continues to the Claim Token input. 

```

 Checking if Docker is running...
CONTAINER ID   NAME      CPU %     MEM USAGE / LIMIT   MEM %     NET I/O   BLOCK I/O   PIDS
 ...Docker is running

```
##### Sad Path
If Docker is not running, then the script exits with an error.
```

 Checking if Docker is running...
Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?

!!! Docker is not running, please start Docker and !!!
!!! once Docker is fully started, re-run this script !!!

```

### Testing
This change is a replacement of the existing output message and prompt function call.  The impact of the change requires the new logic itself to be exercised as well as code path out.  Tested run script with Docker running and not running including bringing existing server all the way up.