### PR TITLE
Fix Chromecasting and Set File Permissions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
-# Docker-Based Plex Media Server
+# Docker-Based Plex Media Server for Mac
+> 	:apple: While this _should_ be mostly compatible with any _'nix_
+> operating system, it is specifically developed and tested on macOS
+> and there are some macOS-specific commands and assumptions in the
+> scripts.
+
 Just `git clone` and run the scripts.
 
 This project provides a **scripted** basic Plex Media Server
 in the project's directory using the official Plex Media Server
-image and docker-compose.
+image and Docker Compose.
 
 It has three idempotent and non-destructive scripts:
   1. run `make-plex` once to create your Plex Media Server
@@ -38,8 +43,12 @@ To Run your Plex Media Server...
   4. When prompted browse to https://www.plex.tv/claim/ (and login)
      to get the Claim token
   5. Enter the Claim token when prompted by the script
-  6. When the script completes, browse to http://app.plex.tv/
-     to finish startup and manage your Plex Media Server
+  6. When the script completes, browse to the URL listed
+     in the output of the `./run-plex` script to finish startup
+     and manage your Plex Media Server
+
+> :point_right: you should always be able to reach your running
+> Plex Media Server at http://localhost:32400/
 
 #### Stop
 To stop your plex Media Server...

--- a/SAMPLE.env
+++ b/SAMPLE.env
@@ -1,3 +1,0 @@
-PLEX_CONFIG=<plex-config-here>
-PLEX_TRANSCODE=<plex-transcode-here>
-PLEX_MEDIA=<your-media-to-be-served-by-plex-here>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,11 +6,12 @@ services:
     image: plexinc/pms-docker
     container_name: plex
     environment:
-      - PLEX_UID=1000
-      - PLEX_GID=513
+      - PLEX_UID
+      - PLEX_GID
       - TZ=America/New_York
       - UMASK_SET=002
-      - PLEX_CLAIM=${PLEX_CLAIM}
+      - PLEX_CLAIM
+      - ADVERTISE_IP
     volumes:
       - ${PLEX_CONFIG}:/config
       - ${PLEX_TRANSCODE}:/transcode

--- a/make-plex
+++ b/make-plex
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Makes a default plex server based out of this directory
+# Makes a default Docker-based plex server based out of this directory
 
 create_directory () {
   dir=$1
@@ -28,6 +28,14 @@ if [[ $response == 'n' ]] || [[ $response == 'N' ]]; then
 fi
 
 echo ""
+current_user=$(whoami)
+echo " Creating Plex Server for current user: ${current_user}"
+current_uid=$(id -u $current_user)
+current_gid=$(id -g $current_user)
+echo "  current user UID: ${current_uid}"
+echo "  current user GID: ${current_gid}"
+
+echo ""
 echo " Creating Plex Server Working Directories..."
 plexserverdatadir="${PWD}/.plex-server/data"
 create_directory "${plexserverdatadir}"
@@ -48,11 +56,15 @@ fi
 
 echo ""
 echo " Setting Environment Variables for Plex Media Server..."
+plexuidenv="PLEX_UID=${current_uid}"
+echo "  [${plexuidenv}]"
+plexgidenv="PLEX_GID=${current_gid}"
+echo "  [${plexgidenv}]"
 configenv="PLEX_CONFIG=${configdir}"
-transcodeenv="PLEX_TRANSCODE=${transcodedir}"
-plexmediaenv="PLEX_MEDIA=${plexservermedia}"
 echo "  [${configenv}]"
+transcodeenv="PLEX_TRANSCODE=${transcodedir}"
 echo "  [${transcodeenv}]"
+plexmediaenv="PLEX_MEDIA=${plexservermedia}"
 echo "  [${plexmediaenv}]"
 
 echo " Creating .env file for Plex Server docker-compose..."
@@ -61,6 +73,8 @@ if [[ -f ".env" ]]; then
   exit 88
 fi
 echo " Writing .env file..."
+echo "${plexuidenv}" >> ".env"
+echo "${plexgidenv}" >> ".env"
 echo "${configenv}" >> ".env"
 echo "${transcodeenv}" >> ".env"
 echo "${plexmediaenv}" >> ".env"

--- a/run-plex
+++ b/run-plex
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Interactively runs the plex server based out of this directory
 # using docker-compose
+# Assumes macOS specifically when getting the local host IP
 
 prompt-to-proceed () {
   echo ""
@@ -30,6 +31,16 @@ fi
 echo " ...Docker is running"
 echo ""
 
+echo " Determining the Advertise Address for Plex Media Server..."
+# macOS https://apple.stackexchange.com/questions/20547/how-do-i-find-my-ip-address-from-the-command-line
+host_ip=$(ipconfig getifaddr en0)
+echo "  The local host IP is [${host_ip}]"
+advertise_address="${host_ip}:32400/"
+echo "  Advertise Address is [${advertise_address}]"
+echo ""
+advertiseipenvstring="ADVERTISE_IP=${advertise_address}"
+
+
 echo " You will first need a Plex Server Claim Token"
 echo " In a web browser, go to..."
 echo "----------------------------------"
@@ -40,7 +51,7 @@ read -p "ENTER the Plex Server Claim Code => " plexclaim
 echo ""
 plexclaimenvstring="PLEX_CLAIM=${plexclaim}"
 
-dockercomposecmd="${plexclaimenvstring} docker-compose "
+dockercomposecmd="${advertiseipenvstring} ${plexclaimenvstring} docker-compose "
 
 echo " The Plex Media Server Config..."
 dcconfigcmd="${dockercomposecmd} config "
@@ -61,9 +72,9 @@ echo ".............................................."
 echo ""
 echo " To Finish the Startup and Administer Plex Media Server"
 echo " In a web browser, go to..."
-echo "---------------------------"
-echo "--- http://app.plex.tv/ ---"
-echo "---------------------------"
+echo "-----------------------------------------------------"
+echo "--- http://${advertise_address} ---"
+echo "-----------------------------------------------------"
 echo " it will take a few minutes for your plexserver to start"
 echo ""
 echo " To STOP the Plex Media Server, enter this command..."

--- a/stop-plex
+++ b/stop-plex
@@ -15,6 +15,15 @@ if ! docker-compose exec plexserver sh -c 'echo " ...Hello, world"' ; then
 fi
 
 echo ""
+echo " Getting Advertise Address from Plex Media Server..."
+ADVERTISE_IP=`docker-compose exec plexserver sh -c 'echo "${ADVERTISE_IP}"'`
+if [[ -z "${ADVERTISE_IP}" ]]; then
+  echo " WARNING: Unable to determine Advertise Address"
+else
+  echo " ...Advertise Address is ${ADVERTISE_IP}"
+fi
+
+echo ""
 echo " Getting Plex Claim Token from Plex Media Server..."
 PLEX_CLAIM=`docker-compose exec plexserver sh -c 'echo "${PLEX_CLAIM}"'`
 if [[ -z "${PLEX_CLAIM}" ]]; then
@@ -35,7 +44,7 @@ fi
 
 echo ""
 echo " Stopping Plex Media Server..."
-PLEX_CLAIM=${PLEX_CLAIM} docker-compose down
+docker-compose down
 echo ".............................................."
 
 echo ""


### PR DESCRIPTION
This change set was intended to and succeed in fixing the ability to cast using the Chrome Browser's casting utility (not Plex's).

The fix seemed to be passing in and setting the `ADVERTISE_IP` based on the local host.  THIS is what makes this now macOS only - the command to get host IP is mac only.

This change set also now sets the `PLEX_UID` and `PLEX_GID` environment variables to those of the user who creates the Plex Server.

Tested on macOS with Chrome 100